### PR TITLE
Update Visual.hx: rotationTo() off by 90 degrees?

### DIFF
--- a/phoenix/Vector.hx
+++ b/phoenix/Vector.hx
@@ -557,9 +557,7 @@ class Vector {
     } //truncate
 
     public inline function rotationTo( other:Vector ) : Float {
-        var theta =  Math.atan2(  other.x - x , other.y - y );
-        var r = -(180.0 + (theta*180.0/Math.PI));
-        return r;
+        return Math.atan2(other.y - y , other.x - x) * 180.0 / Math.PI;
     }
 
 //Transforms


### PR DESCRIPTION
Should rotationTo() be this way instead? This way, a.rotationTo(b) returns the angle in degrees going clockwise from the vector (1,0) (the x-axis, i.e the line vector, not the point `Vector`) to the vector b - a. The previous version returns that angle minus 90 degrees. 

In particular, with the new definition,

```
angle = a.rotationTo(b) * Math.PI / 180;
visual.geometry.transform.rotation = new Quaternion().setFromAxisAngle( new Vector(0, 0, 1), angle);
```

orients visual in the direction b - a, whereas with the previous definition, you had to do 

```
angle = (a.rotationTo(b) + 90) * Math.PI / 180;
```

It's also probably a good idea to clearly describe which input and return values are in radians and degrees across all rotation fields and methods. A naming scheme like rotationToInDegrees(), rotationToInRadians() might be helpful. (Just making note of it here, I know there's still a lot to be done. I can help as well :) )
